### PR TITLE
feat(ci): 自动化 CodeRabbit 审查并同步报告到飞书

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -21,7 +21,7 @@ reviews:
     enabled: true
     auto_incremental_review: true
     drafts: false
-    base_branches: [main, develop]
+    base_branches: [main, dev]
 
   path_filters:
     - "!**/*.lock"

--- a/.github/workflows/ai-review-ci.yml
+++ b/.github/workflows/ai-review-ci.yml
@@ -2,13 +2,13 @@ name: ai_review CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, dev]
     paths:
       - 'ai_review/**'
       - 'scripts/**'
       - '.github/workflows/ai-review-ci.yml'
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev]
     paths:
       - 'ai_review/**'
       - 'scripts/**'

--- a/.github/workflows/coderabbit-report-sync.yml
+++ b/.github/workflows/coderabbit-report-sync.yml
@@ -22,9 +22,14 @@ jobs:
   sync:
     name: Sync CodeRabbit report to Feishu
     runs-on: ubuntu-latest
-    # 第一道过滤: 只处理 coderabbitai[bot] 产生的事件
+    # 第一道过滤:
+    #   1) sender 是 coderabbitai[bot]
+    #   2) issue_comment 必须是 PR 下的评论 (issue.pull_request 不为 null),
+    #      避免 bot 在普通 Issue 下的评论被误同步为 PR 通知
     # 第二道过滤在 Python 脚本内 (summary / review state)
-    if: github.event.sender.login == 'coderabbitai[bot]'
+    if: >
+      github.event.sender.login == 'coderabbitai[bot]' &&
+      (github.event_name != 'issue_comment' || github.event.issue.pull_request != null)
     env:
       FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
       EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/coderabbit-report-sync.yml
+++ b/.github/workflows/coderabbit-report-sync.yml
@@ -1,0 +1,46 @@
+name: CodeRabbit Report Sync
+
+# 将 CodeRabbit 对 PR 的审查结论同步到飞书群
+# 策略 B: 只推 Summary 评论 + Review 结论 (changes_requested / approved)
+# 忽略: walkthrough / ack / 进度提示, 避免刷屏
+#
+# 安全说明:
+#   所有来自 GitHub 事件的不可信字段 (comment.body / review.body / PR title 等)
+#   均通过 env: 块注入环境变量, 不在 run: 指令里内联展开, 避免命令注入.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sync:
+    name: Sync CodeRabbit report to Feishu
+    runs-on: ubuntu-latest
+    # 第一道过滤: 只处理 coderabbitai[bot] 产生的事件
+    # 第二道过滤在 Python 脚本内 (summary / review state)
+    if: github.event.sender.login == 'coderabbitai[bot]'
+    env:
+      FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+      EVENT_NAME: ${{ github.event_name }}
+      REPO_NAME: ${{ github.repository }}
+      SENDER_LOGIN: ${{ github.event.sender.login }}
+      PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
+      PR_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+      COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
+      REVIEW_STATE: ${{ github.event.review.state }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: pip install requests
+      - name: Run sync script
+        run: python scripts/sync_coderabbit_report.py

--- a/.github/workflows/coderabbit-report-sync.yml
+++ b/.github/workflows/coderabbit-report-sync.yml
@@ -32,6 +32,8 @@ jobs:
       (github.event_name != 'issue_comment' || github.event.issue.pull_request != null)
     env:
       FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+      # 可选: 飞书自定义机器人开启签名校验时配置. 没配就走 "IP 白名单/关键词" 模式.
+      FEISHU_WEBHOOK_SECRET: ${{ secrets.FEISHU_WEBHOOK_SECRET }}
       EVENT_NAME: ${{ github.event_name }}
       REPO_NAME: ${{ github.repository }}
       SENDER_LOGIN: ${{ github.event.sender.login }}

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -2,7 +2,7 @@ name: Commit Lint
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/meeting-bot-ci.yml
+++ b/.github/workflows/meeting-bot-ci.yml
@@ -2,13 +2,13 @@ name: meeting_bot CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, dev]
     paths:
       - 'meeting_bot/**'
       - 'scripts/**'
       - '.github/workflows/meeting-bot-ci.yml'
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev]
     paths:
       - 'meeting_bot/**'
       - 'scripts/**'

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -2,9 +2,9 @@ name: Secret Scan
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, dev]
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/scripts/sync_coderabbit_report.py
+++ b/scripts/sync_coderabbit_report.py
@@ -7,6 +7,12 @@
   1. Summary 评论         (issue_comment, body 含 "Summary by CodeRabbit")
   2. Review 结论          (pull_request_review, state ∈ {changes_requested, approved})
 
+安全设计:
+  - 所有外部输入在进入飞书卡片前做结构/白名单校验
+  - pr_title 做 lark_md 转义, 避免 markdown/mention 注入
+  - body 按 UTF-8 字节数截断 (非字符数), 避免中文/emoji 超限被飞书拒收
+  - pr_url 校验必须是 github.com 下的 /pull/<n> 路径
+
 环境变量:
   FEISHU_WEBHOOK_URL        (必需, 飞书群机器人 webhook)
   EVENT_NAME                (issue_comment | pull_request_review)
@@ -22,52 +28,148 @@ from __future__ import annotations
 import os
 import re
 import sys
+from urllib.parse import urlparse
 
 import requests
 
 TIMEOUT = 15
 CODERABBIT_BOT = "coderabbitai[bot]"
-MAX_BODY_LEN = 1500  # 飞书卡片单元素建议不超过 2KB, 留余量
+
+# 飞书 lark_md 元素建议 <= 4KB, 取 3000 字节保守余量
+MAX_BODY_BYTES = 3000
+TRUNCATE_SUFFIX = "\n\n...(已截断, 完整内容见 PR)"
+
+# 已知事件 / review state 白名单
+ALLOWED_EVENTS = {"issue_comment", "pull_request_review"}
+PUSH_REVIEW_STATES = {"changes_requested", "approved"}
 
 SUMMARY_PATTERN = re.compile(r"Summary by CodeRabbit", re.IGNORECASE)
+REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+PR_NUMBER_PATTERN = re.compile(r"^\d+$")
 
+
+# ---------- 过滤 ----------
 
 def should_skip(event: str, sender: str, body: str, state: str) -> tuple[bool, str]:
-    """返回 (是否跳过, 原因)."""
+    """返回 (是否跳过, 原因或匹配类型)."""
+    if event not in ALLOWED_EVENTS:
+        return True, f"未支持的事件类型: {event}"
     if sender != CODERABBIT_BOT:
         return True, f"非 CodeRabbit 事件 (sender={sender})"
 
     if event == "issue_comment":
-        # 只推 Summary 评论
         if not SUMMARY_PATTERN.search(body or ""):
             return True, "非 Summary 评论 (可能是 walkthrough/ack/进度)"
         return False, "summary"
 
-    if event == "pull_request_review":
-        # 只推有结论的 review
-        if state not in {"changes_requested", "approved"}:
-            return True, f"review state={state} 不推送"
-        return False, f"review-{state}"
-
-    return True, f"未支持的事件类型: {event}"
+    # pull_request_review
+    if state not in PUSH_REVIEW_STATES:
+        return True, f"review state={state} 不推送"
+    return False, f"review-{state}"
 
 
-def truncate(body: str, limit: int = MAX_BODY_LEN) -> str:
+# ---------- 校验 / 转义 ----------
+
+def validate_pr_url(url: str) -> str:
+    """只允许 https://github.com/<owner>/<repo>/pull/<n> 格式, 否则返回空串."""
+    if not url:
+        return ""
+    try:
+        p = urlparse(url)
+    except Exception:
+        return ""
+    if p.scheme != "https" or p.netloc != "github.com":
+        return ""
+    parts = [seg for seg in p.path.split("/") if seg]
+    if len(parts) < 4 or parts[2] != "pull" or not parts[3].isdigit():
+        return ""
+    return url
+
+
+def validate_repo(repo: str) -> str:
+    """repo 必须形如 owner/repo, 否则返回空串."""
+    return repo if repo and REPO_PATTERN.match(repo) else ""
+
+
+def validate_pr_number(number: str) -> str:
+    return number if number and PR_NUMBER_PATTERN.match(number) else ""
+
+
+def escape_lark_md(text: str) -> str:
+    """最小转义: 防止 pr_title 突破 markdown 链接上下文 / 触发 @ 提醒."""
+    if not text:
+        return ""
+    return (
+        text.replace("\\", "\\\\")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+        # 飞书 @all/@here/@<user_id> 会触发提醒, 用全角 @ (U+FF20) 替换
+        .replace("@", "＠")
+    )
+
+
+def truncate_bytes(body: str, limit: int = MAX_BODY_BYTES) -> str:
+    """按 UTF-8 字节数截断, 保证不切断多字节字符."""
     if not body:
         return "(无内容)"
-    if len(body) <= limit:
+    encoded = body.encode("utf-8")
+    if len(encoded) <= limit:
         return body
-    return body[:limit] + "\n\n...(已截断, 完整内容见 PR)"
+    # 预留 suffix 的字节
+    suffix_bytes = TRUNCATE_SUFFIX.encode("utf-8")
+    budget = max(limit - len(suffix_bytes), 0)
+    truncated = encoded[:budget]
+    # 回退直到能解码 (避免切在多字节字符中间)
+    for _ in range(4):  # UTF-8 字符最长 4 字节
+        try:
+            return truncated.decode("utf-8") + TRUNCATE_SUFFIX
+        except UnicodeDecodeError:
+            truncated = truncated[:-1]
+    return "(内容截断失败)"
 
 
-def build_card(kind: str, repo: str, pr_number: str, pr_title: str, pr_url: str, body: str) -> dict:
-    """构造飞书交互式卡片."""
+# ---------- 卡片 ----------
+
+def build_card(
+    kind: str,
+    repo: str,
+    pr_number: str,
+    pr_title: str,
+    pr_url: str,
+    body: str,
+) -> dict:
+    """构造飞书交互式卡片 (所有外部输入已校验/转义)."""
     title_map = {
         "summary": ("📝", "CodeRabbit 审查摘要", "blue"),
         "review-approved": ("✅", "CodeRabbit 审查通过", "green"),
         "review-changes_requested": ("❌", "CodeRabbit 要求修改", "red"),
     }
     emoji, title, color = title_map.get(kind, ("🐰", f"CodeRabbit [{kind}]", "grey"))
+
+    safe_title = escape_lark_md(pr_title) or "(无标题)"
+    # 链接文本中如果 pr_url 校验失败, 降级为纯文本标题
+    link_md = f"[{safe_title}]({pr_url})" if pr_url else safe_title
+    header_suffix = f"{repo}#{pr_number}" if repo and pr_number else "PR"
+
+    elements: list[dict] = [
+        {"tag": "div", "text": {"tag": "lark_md", "content": f"**PR**: {link_md}"}},
+        {"tag": "hr"},
+        {"tag": "div", "text": {"tag": "lark_md", "content": truncate_bytes(body)}},
+    ]
+    if pr_url:
+        elements.append(
+            {
+                "tag": "action",
+                "actions": [
+                    {
+                        "tag": "button",
+                        "text": {"tag": "plain_text", "content": "查看 PR"},
+                        "url": pr_url,
+                        "type": "primary",
+                    }
+                ],
+            }
+        )
 
     return {
         "msg_type": "interactive",
@@ -77,34 +179,15 @@ def build_card(kind: str, repo: str, pr_number: str, pr_title: str, pr_url: str,
                 "template": color,
                 "title": {
                     "tag": "plain_text",
-                    "content": f"{emoji} {title} · {repo}#{pr_number}",
+                    "content": f"{emoji} {title} · {header_suffix}",
                 },
             },
-            "elements": [
-                {
-                    "tag": "div",
-                    "text": {"tag": "lark_md", "content": f"**PR**: [{pr_title}]({pr_url})"},
-                },
-                {"tag": "hr"},
-                {
-                    "tag": "div",
-                    "text": {"tag": "lark_md", "content": truncate(body)},
-                },
-                {
-                    "tag": "action",
-                    "actions": [
-                        {
-                            "tag": "button",
-                            "text": {"tag": "plain_text", "content": "查看 PR"},
-                            "url": pr_url,
-                            "type": "primary",
-                        }
-                    ],
-                },
-            ],
+            "elements": elements,
         },
     }
 
+
+# ---------- 主流程 ----------
 
 def main() -> int:
     event = os.environ.get("EVENT_NAME", "")
@@ -122,10 +205,11 @@ def main() -> int:
         print("::warning::缺少 FEISHU_WEBHOOK_URL, 跳过推送")
         return 0
 
-    repo = os.environ.get("REPO_NAME", "")
-    pr_number = os.environ.get("PR_NUMBER", "")
-    pr_title = os.environ.get("PR_TITLE", "")
-    pr_url = os.environ.get("PR_URL", "")
+    # 所有外部输入 -> 校验白名单 / 转义
+    repo = validate_repo(os.environ.get("REPO_NAME", ""))
+    pr_number = validate_pr_number(os.environ.get("PR_NUMBER", ""))
+    pr_url = validate_pr_url(os.environ.get("PR_URL", ""))
+    pr_title = os.environ.get("PR_TITLE", "") or ""
 
     card = build_card(reason, repo, pr_number, pr_title, pr_url, body)
 
@@ -135,7 +219,7 @@ def main() -> int:
     # 飞书群 webhook: 成功返回 code=0 或 StatusCode=0
     if data.get("code", 0) != 0 and data.get("StatusCode", 0) != 0:
         raise RuntimeError(f"飞书群消息发送失败: {data}")
-    print(f"✅ 已推送到飞书: kind={reason}, PR #{pr_number}")
+    print(f"✅ 已推送到飞书: kind={reason}, PR #{pr_number or '?'}")
     return 0
 
 
@@ -143,12 +227,12 @@ if __name__ == "__main__":
     try:
         raise SystemExit(main())
     except requests.HTTPError as e:
-        body = ""
+        err_body = ""
         try:
-            body = e.response.text  # type: ignore[union-attr]
+            err_body = e.response.text  # type: ignore[union-attr]
         except Exception:
             pass
-        print(f"::error::HTTP 错误: {e}\n{body}", file=sys.stderr)
+        print(f"::error::HTTP 错误: {e}\n{err_body}", file=sys.stderr)
         raise SystemExit(1)
     except Exception as e:
         print(f"::error::CodeRabbit 同步脚本异常: {e}", file=sys.stderr)

--- a/scripts/sync_coderabbit_report.py
+++ b/scripts/sync_coderabbit_report.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""CodeRabbit 报告 -> 飞书 Webhook 同步.
+
+监听 GitHub 事件, 过滤出 CodeRabbit 的"有信息量"输出推送到飞书群.
+按照策略 B, 只推以下两类, 忽略 walkthrough / ack / 进度提示, 避免刷屏:
+
+  1. Summary 评论         (issue_comment, body 含 "Summary by CodeRabbit")
+  2. Review 结论          (pull_request_review, state ∈ {changes_requested, approved})
+
+环境变量:
+  FEISHU_WEBHOOK_URL        (必需, 飞书群机器人 webhook)
+  EVENT_NAME                (issue_comment | pull_request_review)
+  REPO_NAME                 (owner/repo)
+  PR_NUMBER, PR_TITLE, PR_URL
+  SENDER_LOGIN              (事件触发者, 用于双保险过滤)
+  COMMENT_BODY              (issue_comment.comment.body 或 pull_request_review.review.body)
+  REVIEW_STATE              (pull_request_review 事件专用)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+import requests
+
+TIMEOUT = 15
+CODERABBIT_BOT = "coderabbitai[bot]"
+MAX_BODY_LEN = 1500  # 飞书卡片单元素建议不超过 2KB, 留余量
+
+SUMMARY_PATTERN = re.compile(r"Summary by CodeRabbit", re.IGNORECASE)
+
+
+def should_skip(event: str, sender: str, body: str, state: str) -> tuple[bool, str]:
+    """返回 (是否跳过, 原因)."""
+    if sender != CODERABBIT_BOT:
+        return True, f"非 CodeRabbit 事件 (sender={sender})"
+
+    if event == "issue_comment":
+        # 只推 Summary 评论
+        if not SUMMARY_PATTERN.search(body or ""):
+            return True, "非 Summary 评论 (可能是 walkthrough/ack/进度)"
+        return False, "summary"
+
+    if event == "pull_request_review":
+        # 只推有结论的 review
+        if state not in {"changes_requested", "approved"}:
+            return True, f"review state={state} 不推送"
+        return False, f"review-{state}"
+
+    return True, f"未支持的事件类型: {event}"
+
+
+def truncate(body: str, limit: int = MAX_BODY_LEN) -> str:
+    if not body:
+        return "(无内容)"
+    if len(body) <= limit:
+        return body
+    return body[:limit] + "\n\n...(已截断, 完整内容见 PR)"
+
+
+def build_card(kind: str, repo: str, pr_number: str, pr_title: str, pr_url: str, body: str) -> dict:
+    """构造飞书交互式卡片."""
+    title_map = {
+        "summary": ("📝", "CodeRabbit 审查摘要", "blue"),
+        "review-approved": ("✅", "CodeRabbit 审查通过", "green"),
+        "review-changes_requested": ("❌", "CodeRabbit 要求修改", "red"),
+    }
+    emoji, title, color = title_map.get(kind, ("🐰", f"CodeRabbit [{kind}]", "grey"))
+
+    return {
+        "msg_type": "interactive",
+        "card": {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "template": color,
+                "title": {
+                    "tag": "plain_text",
+                    "content": f"{emoji} {title} · {repo}#{pr_number}",
+                },
+            },
+            "elements": [
+                {
+                    "tag": "div",
+                    "text": {"tag": "lark_md", "content": f"**PR**: [{pr_title}]({pr_url})"},
+                },
+                {"tag": "hr"},
+                {
+                    "tag": "div",
+                    "text": {"tag": "lark_md", "content": truncate(body)},
+                },
+                {
+                    "tag": "action",
+                    "actions": [
+                        {
+                            "tag": "button",
+                            "text": {"tag": "plain_text", "content": "查看 PR"},
+                            "url": pr_url,
+                            "type": "primary",
+                        }
+                    ],
+                },
+            ],
+        },
+    }
+
+
+def main() -> int:
+    event = os.environ.get("EVENT_NAME", "")
+    sender = os.environ.get("SENDER_LOGIN", "")
+    body = os.environ.get("COMMENT_BODY", "") or ""
+    state = os.environ.get("REVIEW_STATE", "")
+
+    skip, reason = should_skip(event, sender, body, state)
+    if skip:
+        print(f"⏭️  跳过: {reason}")
+        return 0
+
+    webhook = os.environ.get("FEISHU_WEBHOOK_URL")
+    if not webhook:
+        print("::warning::缺少 FEISHU_WEBHOOK_URL, 跳过推送")
+        return 0
+
+    repo = os.environ.get("REPO_NAME", "")
+    pr_number = os.environ.get("PR_NUMBER", "")
+    pr_title = os.environ.get("PR_TITLE", "")
+    pr_url = os.environ.get("PR_URL", "")
+
+    card = build_card(reason, repo, pr_number, pr_title, pr_url, body)
+
+    resp = requests.post(webhook, json=card, timeout=TIMEOUT)
+    resp.raise_for_status()
+    data = resp.json()
+    # 飞书群 webhook: 成功返回 code=0 或 StatusCode=0
+    if data.get("code", 0) != 0 and data.get("StatusCode", 0) != 0:
+        raise RuntimeError(f"飞书群消息发送失败: {data}")
+    print(f"✅ 已推送到飞书: kind={reason}, PR #{pr_number}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except requests.HTTPError as e:
+        body = ""
+        try:
+            body = e.response.text  # type: ignore[union-attr]
+        except Exception:
+            pass
+        print(f"::error::HTTP 错误: {e}\n{body}", file=sys.stderr)
+        raise SystemExit(1)
+    except Exception as e:
+        print(f"::error::CodeRabbit 同步脚本异常: {e}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/sync_coderabbit_report.py
+++ b/scripts/sync_coderabbit_report.py
@@ -71,7 +71,16 @@ def should_skip(event: str, sender: str, body: str, state: str) -> tuple[bool, s
 # ---------- 校验 / 转义 ----------
 
 def validate_pr_url(url: str) -> str:
-    """只允许 https://github.com/<owner>/<repo>/pull/<n> 格式, 否则返回空串."""
+    """只允许 https://github.com/<owner>/<repo>/pull/<n> 精确格式.
+
+    拒绝:
+        - 非 https / 非 github.com
+        - /pull/<n>/files 这类子路径 (必须正好 4 段)
+        - 带 query string 或 fragment
+        - pull 号非纯数字
+
+    返回规范化 URL 或空串.
+    """
     if not url:
         return ""
     try:
@@ -80,10 +89,17 @@ def validate_pr_url(url: str) -> str:
         return ""
     if p.scheme != "https" or p.netloc != "github.com":
         return ""
-    parts = [seg for seg in p.path.split("/") if seg]
-    if len(parts) < 4 or parts[2] != "pull" or not parts[3].isdigit():
+    if p.query or p.fragment:
         return ""
-    return url
+    parts = [seg for seg in p.path.split("/") if seg]
+    if (
+        len(parts) != 4
+        or parts[2] != "pull"
+        or not parts[3].isdigit()
+    ):
+        return ""
+    owner, repo, _, number = parts
+    return f"https://github.com/{owner}/{repo}/pull/{number}"
 
 
 def validate_repo(repo: str) -> str:
@@ -96,7 +112,7 @@ def validate_pr_number(number: str) -> str:
 
 
 def escape_lark_md(text: str) -> str:
-    """最小转义: 防止 pr_title 突破 markdown 链接上下文 / 触发 @ 提醒."""
+    """最小转义: 防止 pr_title 突破 markdown 链接上下文 / 触发 @ 提醒 / 注入 HTML 标签."""
     if not text:
         return ""
     return (
@@ -105,6 +121,26 @@ def escape_lark_md(text: str) -> str:
         .replace("]", "\\]")
         # 飞书 @all/@here/@<user_id> 会触发提醒, 用全角 @ (U+FF20) 替换
         .replace("@", "＠")
+        # 阻止 <b>xxx</b> 之类 HTML/lark 标签注入
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+def sanitize_lark_body(text: str) -> str:
+    """对非 trusted 的长文本做 lark_md 注入最小净化.
+
+    即使 sender 已经是 coderabbitai[bot], 其 body 仍可能是转发的用户输入
+    (比如 PR 作者写在 PR body 里的 @all, 再被 bot 引用). 所以对 body 也做
+    一次基础净化: 替换 @ 防误提醒, 用 HTML 实体替换 <>, 防止潜在的 lark 标签注入.
+    Markdown 链接/粗体等格式保留, 因为 CodeRabbit 的输出靠它渲染可读性.
+    """
+    if not text:
+        return ""
+    return (
+        text.replace("@", "＠")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
     )
 
 
@@ -154,7 +190,13 @@ def build_card(
     elements: list[dict] = [
         {"tag": "div", "text": {"tag": "lark_md", "content": f"**PR**: {link_md}"}},
         {"tag": "hr"},
-        {"tag": "div", "text": {"tag": "lark_md", "content": truncate_bytes(body)}},
+        {
+            "tag": "div",
+            "text": {
+                "tag": "lark_md",
+                "content": truncate_bytes(sanitize_lark_body(body)),
+            },
+        },
     ]
     if pr_url:
         elements.append(

--- a/scripts/sync_coderabbit_report.py
+++ b/scripts/sync_coderabbit_report.py
@@ -25,9 +25,13 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
 import os
 import re
 import sys
+import time
 from urllib.parse import urlparse
 
 import requests
@@ -255,7 +259,16 @@ def main() -> int:
 
     card = build_card(reason, repo, pr_number, pr_title, pr_url, body)
 
-    resp = requests.post(webhook, json=card, timeout=TIMEOUT)
+    # 如果配了 FEISHU_WEBHOOK_SECRET, 开启签名校验模式 (飞书自定义机器人的 "签名校验")
+    # 否则走 "IP 白名单 / 关键词" 模式, 不带签名字段
+    webhook_secret = os.environ.get("FEISHU_WEBHOOK_SECRET")
+    payload: dict = dict(card)
+    if webhook_secret:
+        timestamp = str(int(time.time()))
+        payload["timestamp"] = timestamp
+        payload["sign"] = _sign(timestamp, webhook_secret)
+
+    resp = requests.post(webhook, json=payload, timeout=TIMEOUT)
     resp.raise_for_status()
     data = resp.json()
     # 飞书群 webhook: 成功时 code 与 StatusCode 都应为 0 (一般只返回其中之一);
@@ -264,6 +277,16 @@ def main() -> int:
         raise RuntimeError(f"飞书群消息发送失败: {data}")
     print(f"✅ 已推送到飞书: kind={reason}, PR #{pr_number or '?'}")
     return 0
+
+
+def _sign(timestamp: str, secret: str) -> str:
+    """飞书自定义机器人签名: HMAC-SHA256(secret, f'{timestamp}\\n{secret}') 再 base64.
+
+    参考: https://open.feishu.cn/document/client-docs/bot-v1/add-custom-bot
+    """
+    string_to_sign = f"{timestamp}\n{secret}"
+    hmac_code = hmac.new(string_to_sign.encode("utf-8"), digestmod=hashlib.sha256).digest()
+    return base64.b64encode(hmac_code).decode("utf-8")
 
 
 if __name__ == "__main__":

--- a/scripts/sync_coderabbit_report.py
+++ b/scripts/sync_coderabbit_report.py
@@ -258,8 +258,9 @@ def main() -> int:
     resp = requests.post(webhook, json=card, timeout=TIMEOUT)
     resp.raise_for_status()
     data = resp.json()
-    # 飞书群 webhook: 成功返回 code=0 或 StatusCode=0
-    if data.get("code", 0) != 0 and data.get("StatusCode", 0) != 0:
+    # 飞书群 webhook: 成功时 code 与 StatusCode 都应为 0 (一般只返回其中之一);
+    # 任一字段非零都视为失败, 用 OR 而非 AND 避免单字段错误被吞
+    if data.get("code", 0) != 0 or data.get("StatusCode", 0) != 0:
         raise RuntimeError(f"飞书群消息发送失败: {data}")
     print(f"✅ 已推送到飞书: kind={reason}, PR #{pr_number or '?'}")
     return 0


### PR DESCRIPTION
## Summary
- `.coderabbit.yaml`: base_branches 改为 `[main, dev]`, 让 `dev` 分支 PR 自动触发 CodeRabbit review (之前只对 main/develop 生效, 导致 PR #1 不自动跑)
- 新增 `coderabbit-report-sync.yml` workflow, 监听 `issue_comment` + `pull_request_review` 事件, 把 CodeRabbit 的产出同步到飞书群
- 新增 `scripts/sync_coderabbit_report.py`, 按策略 B 只推"有信息量"的内容:
  - ✅ Summary 评论 (Summary by CodeRabbit)
  - ✅ Review 结论 (state = approved / changes_requested)
  - ⏭️ 跳过 walkthrough / ack / 进度提示, 避免刷屏
- 复用现有 `FEISHU_WEBHOOK_URL` secret, 和现有通知在同一个群

## 设计要点
- **双层过滤**: workflow-level `if: sender == 'coderabbitai[bot]'` + 脚本内业务过滤, 省下大部分 runner 分钟数
- **安全**: 所有来自事件的不可信字段 (comment body / PR title) 通过 `env:` 注入, 不在 `run:` 内联展开, 避免命令注入
- **截断**: body 超过 1500 字符截断, 避免飞书卡片溢出
- **类型区分**: Summary 用蓝色卡片, approved 绿色, changes_requested 红色

## Test plan
- [x] Python 语法 / YAML 结构校验通过
- [x] `should_skip` 函数 7 个用例 smoke test 全部符合预期 (walkthrough/ack/non-bot 跳过; summary/approved/changes_requested 推送)
- [ ] Merge 后的下一个 PR 应自动触发 CodeRabbit review (验证 base_branches 修复)
- [ ] CodeRabbit 发 Summary 评论后, 飞书群应收到一张蓝色卡片
- [ ] CodeRabbit submit changes_requested/approved review 后, 飞书群应收到红色/绿色卡片

## Demo
本 PR 合并后, 下一个 PR 即为完整端到端 demo. 也可在本 PR 上 `@coderabbitai review` 先触发一次人工审查 (新 workflow 尚未生效, 但能验证 CodeRabbit 本身对 dev 分支的 review 能力).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 变更日志

* **Chores**
  * 调整 CI 与审查自动化的目标分支：将原先的 main + develop 更新为 main + dev，已同步到多个工作流触发配置。
* **New Features**
  * 新增审查同步流程：自动将 PR 审查结果与摘要以富交互卡片推送到飞书，包含状态过滤、内容截断与安全处理，提升审查通知可见性与响应效率。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->