### PR TITLE
fix: extract all docx block types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ htmlcov/
 .env
 .env.*
 !.env.example
+.mcp.json
 *.pem
 *.key
 secrets/

--- a/scripts/feishu_content.py
+++ b/scripts/feishu_content.py
@@ -92,28 +92,80 @@ def fetch_docx(tenant_token: str, doc_id: str) -> str:
     return _blocks_to_text(all_blocks)
 
 
+# 飞书 docx block_type → markdown 前缀
+# 参考: https://open.feishu.cn/document/server-docs/docs/docs/docx-v1/data-structure/block
+_PREFIX_BY_BLOCK_TYPE: dict[int, str] = {
+    2: "",  # text 段落
+    3: "# ",  # heading1
+    4: "## ",  # heading2
+    5: "### ",  # heading3
+    6: "#### ",  # heading4
+    7: "##### ",  # heading5
+    8: "###### ",  # heading6
+    9: "###### ",  # heading7 (md 最多 6 级)
+    10: "###### ",  # heading8
+    11: "###### ",  # heading9
+    12: "- ",  # bullet (无序列表)
+    13: "1. ",  # ordered (有序列表)
+    14: "",  # code (特殊处理: fenced code)
+    15: "> ",  # quote 引用
+    17: "- [ ] ",  # todo 待办
+    19: "",  # callout 高亮块
+    22: "> ",  # quote_container 引用容器
+}
+
+
+def _extract_block_text(block: dict[str, Any]) -> str:
+    """从 block 提取所有 text_run.content 拼接, 不依赖 block_type.
+
+    Fallback 策略: 扫所有 dict 字段, 任何含 elements 数组且元素含
+    text_run.content 的, 收集起来. 这样能兜住 Feishu 新加的 block 类型.
+    """
+    pieces: list[str] = []
+    for value in block.values():
+        if not isinstance(value, dict):
+            continue
+        elements = value.get("elements")
+        if not isinstance(elements, list):
+            continue
+        for e in elements:
+            if not isinstance(e, dict):
+                continue
+            text_run = e.get("text_run")
+            if isinstance(text_run, dict):
+                content = text_run.get("content", "")
+                if isinstance(content, str) and content:
+                    pieces.append(content)
+    return "".join(pieces)
+
+
 def _blocks_to_text(blocks: list[dict[str, Any]]) -> str:
-    """简化提取 text + heading1-9 的文字内容, 忽略图片/表格/代码块."""
+    """提取所有已知 block_type 的文字, 加 markdown 前缀.
+
+    覆盖: text / heading1-9 / bullet / ordered / todo / quote / callout / code /
+    quote_container. 未在白名单内的 block_type 走 fallback (无前缀但保留文字).
+
+    block_type=1 是 page 根容器, 跳过.
+    """
     out: list[str] = []
     for b in blocks:
         t = b.get("block_type")
-        if t == 2:  # text
-            text = "".join(
-                e.get("text_run", {}).get("content", "")
-                for e in b.get("text", {}).get("elements", [])
-            )
-            if text.strip():
-                out.append(text.strip())
-        elif isinstance(t, int) and 3 <= t <= 11:  # heading 1-9 (block_type 3..11)
-            level = t - 2  # heading{level}
-            field = f"heading{level}"
-            text = "".join(
-                e.get("text_run", {}).get("content", "")
-                for e in b.get(field, {}).get("elements", [])
-            )
-            if text.strip():
-                prefix = "#" * min(level, 6)
-                out.append(f"{prefix} {text.strip()}")
+        if t == 1:
+            # page 根容器, 没自己的文字内容
+            continue
+        text = _extract_block_text(b)
+        if not text.strip():
+            continue
+        if isinstance(t, int) and t in _PREFIX_BY_BLOCK_TYPE:
+            prefix = _PREFIX_BY_BLOCK_TYPE[t]
+            if t == 14:
+                # 代码块用 fenced code 包起来
+                out.append(f"```\n{text.strip()}\n```")
+            else:
+                out.append(f"{prefix}{text.strip()}")
+        else:
+            # 未知 block_type, 文字仍保留 (无前缀)
+            out.append(text.strip())
     return "\n\n".join(out)
 
 

--- a/scripts/test_blocks_to_text.py
+++ b/scripts/test_blocks_to_text.py
@@ -1,0 +1,103 @@
+"""_blocks_to_text 单测 - 纯逻辑, 无外部依赖."""
+from __future__ import annotations
+
+from feishu_content import _blocks_to_text
+
+
+def _make_block(block_type: int, field_name: str, text: str) -> dict:
+    """Helper: 构造一个飞书 docx block."""
+    return {
+        "block_type": block_type,
+        field_name: {"elements": [{"text_run": {"content": text}}]},
+    }
+
+
+def test_text_and_heading() -> None:
+    blocks = [
+        _make_block(3, "heading1", "标题一"),
+        _make_block(2, "text", "段落一"),
+    ]
+    text = _blocks_to_text(blocks)
+    assert "# 标题一" in text
+    assert "段落一" in text
+
+
+def test_bullet_and_ordered() -> None:
+    blocks = [
+        _make_block(12, "bullet", "无序项"),
+        _make_block(13, "ordered", "有序项"),
+    ]
+    text = _blocks_to_text(blocks)
+    assert "- 无序项" in text
+    assert "1. 有序项" in text
+
+
+def test_todo() -> None:
+    blocks = [_make_block(17, "todo", "买牛奶")]
+    assert "- [ ] 买牛奶" in _blocks_to_text(blocks)
+
+
+def test_quote_and_quote_container() -> None:
+    blocks = [
+        _make_block(15, "quote", "引用文字"),
+        _make_block(22, "quote_container", "容器引用"),
+    ]
+    text = _blocks_to_text(blocks)
+    assert "> 引用文字" in text
+    assert "> 容器引用" in text
+
+
+def test_code_fenced() -> None:
+    blocks = [_make_block(14, "code", "print('hello')")]
+    text = _blocks_to_text(blocks)
+    assert "```\nprint('hello')\n```" in text
+
+
+def test_callout() -> None:
+    blocks = [_make_block(19, "callout", "注意事项")]
+    assert "注意事项" in _blocks_to_text(blocks)
+
+
+def test_page_root_skipped() -> None:
+    """block_type=1 (page 根容器) 应被跳过."""
+    blocks = [
+        {"block_type": 1, "page": {"elements": [{"text_run": {"content": "root"}}]}},
+        _make_block(2, "text", "正文"),
+    ]
+    text = _blocks_to_text(blocks)
+    assert "root" not in text
+    assert "正文" in text
+
+
+def test_unknown_type_fallback() -> None:
+    """未知 block_type 仍保留文字, 无前缀."""
+    blocks = [_make_block(999, "mystery", "神秘内容")]
+    text = _blocks_to_text(blocks)
+    assert "神秘内容" in text
+    assert text.strip() == "神秘内容"
+
+
+def test_empty_text_skipped() -> None:
+    """空文字 block 不出现在输出里."""
+    blocks = [_make_block(2, "text", "   ")]
+    assert _blocks_to_text(blocks) == ""
+
+
+def test_mixed_block_types() -> None:
+    """模拟真实文档: heading + text + bullet + todo 混合."""
+    blocks = [
+        {"block_type": 1, "page": {"elements": []}},
+        _make_block(3, "heading1", "会议纪要"),
+        _make_block(2, "text", "2026年4月16日"),
+        _make_block(12, "bullet", "讨论了CI/CD流程"),
+        _make_block(12, "bullet", "飞书任务自动同步"),
+        _make_block(17, "todo", "完成MCP配置"),
+        _make_block(17, "todo", "编写ONBOARDING文档"),
+    ]
+    text = _blocks_to_text(blocks)
+    assert "# 会议纪要" in text
+    assert "2026年4月16日" in text
+    assert "- 讨论了CI/CD流程" in text
+    assert "- 飞书任务自动同步" in text
+    assert "- [ ] 完成MCP配置" in text
+    assert "- [ ] 编写ONBOARDING文档" in text


### PR DESCRIPTION
## Summary
- `_blocks_to_text` only handled text + headings (block_type 2-11), dropping bullets, ordered lists, todos, quotes, code blocks, callouts, and quote containers
- This caused issue #10 to extract 0 action items from real meeting docs
- Now covers block_type 2-22 with markdown prefixes + fallback for unknown types
- Added `test_blocks_to_text.py` with 10 pure-logic tests (zero external deps)
- Added `.mcp.json` to `.gitignore`

## Test plan
- [ ] CI passes (pytest on all test files)
- [ ] Merge to dev → main, then re-test E2E with wiki/docx link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 扩展了Feishu文档处理能力，现支持标题、列表、代办项、引用和代码块等多种内容格式。

* **Tests**
  * 新增测试模块以验证文档块转换的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->